### PR TITLE
Update gist JSON files (run 17022416732)

### DIFF
--- a/gist-factory/all-gists.json
+++ b/gist-factory/all-gists.json
@@ -1,28 +1,15 @@
 [
-    {
-        "id": "59614cb8e85a429214d9d4f15d7ae58f",
-        "filename": "1201-kubernetes-tf-111.json",
-        "description": "Gist for 1201-kubernetes-tf-111.json",
-        "content": {
-            "schemaVersion": 1,
-            "label": "status",
-            "message": "not started",
-            "color": "red",
-            "style": "flat"
-        },
-        "operation": "delete"
+  {
+    "id": "693cc07bb0b15ef79d63abdbb2fc4af3",
+    "filename": "1201-kubernetes-tf-112.json",
+    "description": "Gist for 1201-kubernetes-tf-112.json",
+    "content": {
+      "schemaVersion": 1,
+      "label": "status",
+      "message": "not started",
+      "color": "red",
+      "style": "flat"
     },
-    {
-        "id": null,
-        "filename": "1201-kubernetes-tf-112.json",
-        "description": "Gist for 1201-kubernetes-tf-112.json",
-        "content": {
-            "schemaVersion": 1,
-            "label": "status",
-            "message": "not started",
-            "color": "red",
-            "style": "flat"
-        },
-        "operation": "create"
-    }
+    "operation": "created"
+  }
 ]


### PR DESCRIPTION
This pull request updates the `gist-factory/all-gists.json` file to reflect the removal of an outdated gist and the addition of a new one, while also correcting the operation status for gist creation.

Gist management updates:

* Removed the gist entry for `1201-kubernetes-tf-111.json` and its associated metadata, indicating it is no longer needed.
* Added a new gist entry for `1201-kubernetes-tf-112.json` with updated metadata and a valid gist ID.

Metadata and status corrections:

* Changed the operation status for the new gist from `"create"` to `"created"` for consistency and accuracy.